### PR TITLE
Hide pay with amazon button if the payment method hasn't been configured

### DIFF
--- a/app/overrides/spree/orders/edit/add_pay_with_amazon.html.erb.deface
+++ b/app/overrides/spree/orders/edit/add_pay_with_amazon.html.erb.deface
@@ -1,2 +1,4 @@
 <!-- insert_bottom "[data-hook='cart_buttons']" -->
-<%= render :partial => "spree/amazon/login" %>
+<% if Spree::Gateway::Amazon.count > 0 %>
+  <%= render :partial => "spree/amazon/login" %>
+<% end %>


### PR DESCRIPTION
This will need to be applied to all branches.